### PR TITLE
Boot supernova with Server.boot(supernova=True)

### DIFF
--- a/supriya/__init__.py
+++ b/supriya/__init__.py
@@ -13,6 +13,7 @@ if not output_path.exists():
 
 config = configparser.ConfigParser()
 config.read_dict({"core": {"scsynth_path": "scsynth"}})
+config.read_dict({"core": {"supernova_path": "supernova"}})
 config_path = pathlib.Path(platformdirs.user_config_dir("supriya", "supriya"))
 config_path = config_path / "supriya.cfg"
 if not config_path.exists():

--- a/supriya/providers.py
+++ b/supriya/providers.py
@@ -608,19 +608,29 @@ class Provider(metaclass=abc.ABCMeta):
 
     @classmethod
     def realtime(
-        cls, scsynth_path=None, options=None, port=None, **kwargs
+        cls, scsynth_path=None, options=None, port=None, supernova=False, **kwargs
     ) -> "RealtimeProvider":
         server = Server()
-        server.boot(port=port, scsynth_path=scsynth_path, options=options, **kwargs)
+        server.boot(
+            port=port,
+            scsynth_path=scsynth_path,
+            options=options,
+            supernova=supernova,
+            **kwargs,
+        )
         return cast("RealtimeProvider", cls.from_context(server))
 
     @classmethod
     async def realtime_async(
-        cls, scsynth_path=None, options=None, port=None, **kwargs
+        cls, scsynth_path=None, options=None, port=None, supernova=False, **kwargs
     ) -> "RealtimeProvider":
         server = AsyncServer()
         await server.boot(
-            port=port, scsynth_path=scsynth_path, options=options, **kwargs
+            port=port,
+            scsynth_path=scsynth_path,
+            options=options,
+            supernova=supernova,
+            **kwargs,
         )
         return cast("RealtimeProvider", cls.from_context(server))
 

--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -309,7 +309,13 @@ class AsyncServer(BaseServer):
         if isinstance(response, FailResponse):
             await self._shutdown()
             raise supriya.exceptions.TooManyClients
-        self._client_id, self._maximum_logins = response.action[1], response.action[2]
+        if len(response.action) == 2:  # supernova doesn't provide a max logins value
+            self._client_id, self._maximum_logins = (
+                response.action[1],
+                self._options.maximum_logins,
+            )
+        else:
+            self._client_id, self._maximum_logins = response.action[1:3]
 
     async def _setup_system_synthdefs(self):
         pass

--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -1101,9 +1101,11 @@ class Server(BaseServer):
         response = request.communicate(server=self)
         return response.query_tree_group
 
-    def reboot(self, options: Optional[Options] = None, **kwargs) -> "Server":
+    def reboot(
+        self, options: Optional[Options] = None, supernova=False, **kwargs
+    ) -> "Server":
         self.quit()
-        self.boot(options=options, **kwargs)
+        self.boot(options=options, supernova=supernova, **kwargs)
         return self
 
     def reset(self) -> "Server":

--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -1030,13 +1030,14 @@ class Server(BaseServer):
         port: int = DEFAULT_PORT,
         scsynth_path: Optional[str] = None,
         options: Optional[Options] = None,
+        supernova: bool = False,
         **kwargs,
     ) -> "Server":
         if self.is_running:
             raise supriya.exceptions.ServerOnline
         port = port or DEFAULT_PORT
         self._options = new(options or Options(), **kwargs)
-        scsynth_path = find(scsynth_path)
+        scsynth_path = find(scsynth_path, supernova)
         self._process_protocol = SyncProcessProtocol()
         self._process_protocol.boot(self._options, scsynth_path, port)
         self._ip_address = ip_address

--- a/supriya/realtime/servers.py
+++ b/supriya/realtime/servers.py
@@ -331,6 +331,7 @@ class AsyncServer(BaseServer):
         port: int = DEFAULT_PORT,
         scsynth_path: Optional[str] = None,
         options: Optional[Options] = None,
+        supernova: bool = False,
         **kwargs,
     ) -> "AsyncServer":
         if self._is_running:
@@ -340,7 +341,7 @@ class AsyncServer(BaseServer):
         self._boot_future = loop.create_future()
         self._quit_future = loop.create_future()
         self._options = new(options or Options(), **kwargs)
-        scsynth_path = find(scsynth_path)
+        scsynth_path = find(scsynth_path, supernova)
         self._process_protocol = AsyncProcessProtocol()
         await self._process_protocol.boot(self._options, scsynth_path, port)
         if not await self._process_protocol.boot_future:

--- a/supriya/scsynth.py
+++ b/supriya/scsynth.py
@@ -155,23 +155,30 @@ class Options:
         )
 
 
-def _fallback_scsynth_path():
+def _fallback_scsynth_path(supernova: bool = False):
     paths = []
     system = platform.system()
+    executable = "supernova" if supernova else "scsynth"
     if system == "Linux":
-        paths.extend([Path("/usr/bin/scsynth"), Path("/usr/local/bin/scsynth")])
+        paths.extend(
+            [Path("/usr/bin/" + executable), Path("/usr/local/bin/" + executable)]
+        )
     elif system == "Darwin":
-        paths.append(Path("/Applications/SuperCollider.app/Contents/Resources/scsynth"))
+        paths.append(
+            Path("/Applications/SuperCollider.app/Contents/Resources/" + executable)
+        )
     elif system == "Windows":
-        paths.extend(Path(r"C:\Program Files").glob(r"SuperCollider*\scsynth.exe"))
+        paths.extend(
+            Path(r"C:\Program Files").glob(r"SuperCollider*\\" + executable + ".exe")
+        )
     for path in paths:
         if path.exists():
             return path
     return None
 
 
-def find(scsynth_path=None):
-    """Find the ``scsynth`` executable.
+def find(scsynth_path=None, supernova: bool = False):
+    """Find the ``scsynth`` or ``supernova`` executable.
 
     The following paths, if defined, will be searched (prioritised as ordered):
 
@@ -181,24 +188,25 @@ def find(scsynth_path=None):
     4. The user's ``PATH``
     5. Common installation directories of the SuperCollider application.
 
-    Returns a path to the ``scsynth`` executable.
+    Returns a path to the ``scsynth`` or ``supernova`` executable.
     Raises ``RuntimeError`` if no path is found.
     """
+    executable = "supernova" if supernova else "scsynth"
     scsynth_path = Path(
         scsynth_path
-        or os.environ.get("SCSYNTH_PATH")
-        or supriya.config.get("core", "scsynth_path")
-        or "scsynth"
+        or os.environ.get("SUPERNOVA_PATH" if supernova else "SCSYNTH_PATH")
+        or supriya.config.get("core", executable + "_path")
+        or executable
     )
     if scsynth_path.is_absolute() and uqbar.io.find_executable(scsynth_path):
         return scsynth_path
     scsynth_path_candidates = uqbar.io.find_executable(scsynth_path.name)
     if scsynth_path_candidates:
         return Path(scsynth_path_candidates[0])
-    fallback_path = _fallback_scsynth_path()
+    fallback_path = _fallback_scsynth_path(supernova)
     if fallback_path is not None:
         return fallback_path
-    raise RuntimeError("Failed to locate scsynth")
+    raise RuntimeError("Failed to locate " + executable)
 
 
 def kill(supernova=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,11 +21,30 @@ def server():
     server.quit()
 
 
+@pytest.fixture
+def server_supernova():
+    server = supriya.Server()
+    server.latency = 0.0
+    server.boot(supernova=True)
+    server.add_synthdef(supriya.assets.synthdefs.default)
+    yield server
+    server.quit()
+
+
 @pytest.fixture(scope="module")
 def persistent_server():
     server = supriya.Server()
     server.latency = 0.0
     server.boot()
+    yield server
+    server.quit()
+
+
+@pytest.fixture(scope="module")
+def persistent_server_supernova():
+    server = supriya.Server()
+    server.latency = 0.0
+    server.boot(supernova=True)
     yield server
     server.quit()
 

--- a/tests/providers/test_Provider.py
+++ b/tests/providers/test_Provider.py
@@ -12,3 +12,45 @@ def test_Provider_from_context(session, server):
     assert nonrealtime_provider.session is session
     with pytest.raises(ValueError):
         Provider.from_context(23)
+
+
+def test_Provider_realtime():
+    realtime_provider = Provider.realtime()
+    assert isinstance(realtime_provider, RealtimeProvider)
+    assert realtime_provider.server.is_running
+    assert realtime_provider.server.is_owner
+    realtime_provider.server.quit()
+    assert not realtime_provider.server.is_running
+    assert not realtime_provider.server.is_owner
+
+
+def test_Provider_realtime_supernova():
+    realtime_provider = Provider.realtime(supernova=True)
+    assert isinstance(realtime_provider, RealtimeProvider)
+    assert realtime_provider.server.is_running
+    assert realtime_provider.server.is_owner
+    realtime_provider.server.quit()
+    assert not realtime_provider.server.is_running
+    assert not realtime_provider.server.is_owner
+
+
+@pytest.mark.asyncio
+async def test_Provider_realtime_async():
+    realtime_provider = await Provider.realtime_async()
+    assert isinstance(realtime_provider, RealtimeProvider)
+    assert realtime_provider.server.is_running
+    assert realtime_provider.server.is_owner
+    await realtime_provider.server.quit()
+    assert not realtime_provider.server.is_running
+    assert not realtime_provider.server.is_owner
+
+
+@pytest.mark.asyncio
+async def test_Provider_realtime_async_supernova():
+    realtime_provider = await Provider.realtime_async(supernova=True)
+    assert isinstance(realtime_provider, RealtimeProvider)
+    assert realtime_provider.server.is_running
+    assert realtime_provider.server.is_owner
+    await realtime_provider.server.quit()
+    assert not realtime_provider.server.is_running
+    assert not realtime_provider.server.is_owner

--- a/tests/realtime/test_AsyncServer.py
+++ b/tests/realtime/test_AsyncServer.py
@@ -23,11 +23,34 @@ async def test_boot_only():
 
 
 @pytest.mark.asyncio
+async def test_boot_only_supernova():
+    server = AsyncServer()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_and_quit():
     server = AsyncServer()
     assert not server.is_running
     assert not server.is_owner
     await server.boot()
+    assert server.is_running
+    assert server.is_owner
+    await server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+
+
+@pytest.mark.asyncio
+async def test_boot_and_quit_supernova():
+    server = AsyncServer()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.boot(supernova=True)
     assert server.is_running
     assert server.is_owner
     await server.quit()
@@ -50,11 +73,41 @@ async def test_boot_and_boot():
 
 
 @pytest.mark.asyncio
+async def test_boot_and_boot_supernova():
+    server = AsyncServer()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+    with pytest.raises(exceptions.ServerOnline):
+        await server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_and_quit_and_quit():
     server = AsyncServer()
     assert not server.is_running
     assert not server.is_owner
     await server.boot()
+    assert server.is_running
+    assert server.is_owner
+    await server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+
+
+@pytest.mark.asyncio
+async def test_boot_and_quit_and_quit_supernova():
+    server = AsyncServer()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.boot(supernova=True)
     assert server.is_running
     assert server.is_owner
     await server.quit()
@@ -80,6 +133,20 @@ async def test_boot_and_connect():
 
 
 @pytest.mark.asyncio
+async def test_boot_and_connect_supernova():
+    server = AsyncServer()
+    assert not server.is_running
+    assert not server.is_owner
+    await server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+    with pytest.raises(exceptions.ServerOnline):
+        await server.connect()
+    assert server.is_running
+    assert server.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_a_and_boot_b_cannot_boot():
     server_a, server_b = AsyncServer(), AsyncServer()
     assert not server_a.is_running and not server_a.is_owner
@@ -89,6 +156,20 @@ async def test_boot_a_and_boot_b_cannot_boot():
     assert not server_b.is_running and not server_b.is_owner
     with pytest.raises(exceptions.ServerCannotBoot):
         await server_b.boot(maximum_logins=4)
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+
+
+@pytest.mark.asyncio
+async def test_boot_a_and_boot_b_cannot_boot_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=4, supernova=True)
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.ServerCannotBoot):
+        await server_b.boot(maximum_logins=4, supernova=True)
     assert server_a.is_running and server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
 
@@ -126,6 +207,24 @@ async def test_boot_a_and_connect_b_and_quit_a():
 
 
 @pytest.mark.asyncio
+async def test_boot_a_and_connect_b_and_quit_a_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=2, supernova=True)
+    await server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    await server_a.quit()
+    assert not server_a.is_running and not server_a.is_owner
+    for _ in range(100):
+        await asyncio.sleep(0.1)
+        if not server_b.is_running:
+            break
+    assert not server_b.is_running and not server_b.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_a_and_connect_b_and_disconnect_b():
     server_a, server_b = AsyncServer(), AsyncServer()
     assert not server_a.is_running and not server_a.is_owner
@@ -140,11 +239,40 @@ async def test_boot_a_and_connect_b_and_disconnect_b():
 
 
 @pytest.mark.asyncio
+async def test_boot_a_and_connect_b_and_disconnect_b_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=2, supernova=True)
+    await server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    await server_b.disconnect()
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_a_and_connect_b_and_disconnect_a():
     server_a, server_b = AsyncServer(), AsyncServer()
     assert not server_a.is_running and not server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
     await server_a.boot(maximum_logins=2)
+    await server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.OwnedServerShutdown):
+        await server_a.disconnect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+
+
+@pytest.mark.asyncio
+async def test_boot_a_and_connect_b_and_disconnect_a_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=2, supernova=True)
     await server_b.connect()
     assert server_a.is_running and server_a.is_owner
     assert server_b.is_running and not server_b.is_owner
@@ -170,11 +298,44 @@ async def test_boot_a_and_connect_b_and_quit_b():
 
 
 @pytest.mark.asyncio
+async def test_boot_a_and_connect_b_and_quit_b_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=2, supernova=True)
+    await server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.UnownedServerShutdown):
+        await server_b.quit()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+
+
+@pytest.mark.asyncio
 async def test_boot_a_and_connect_b_and_force_quit_b():
     server_a, server_b = AsyncServer(), AsyncServer()
     assert not server_a.is_running and not server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
     await server_a.boot(maximum_logins=2)
+    await server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    await server_b.quit(force=True)
+    assert not server_b.is_running and not server_b.is_owner
+    for _ in range(100):
+        await asyncio.sleep(0.1)
+        if not server_a.is_running:
+            break
+    assert not server_a.is_running and not server_a.is_owner
+
+
+@pytest.mark.asyncio
+async def test_boot_a_and_connect_b_and_force_quit_b_supernova():
+    server_a, server_b = AsyncServer(), AsyncServer()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    await server_a.boot(maximum_logins=2, supernova=True)
     await server_b.connect()
     assert server_a.is_running and server_a.is_owner
     assert server_b.is_running and not server_b.is_owner

--- a/tests/realtime/test_Server.py
+++ b/tests/realtime/test_Server.py
@@ -46,6 +46,39 @@ def test_boot_options():
             server.quit()
 
 
+def test_boot_options_supernova():
+    server = supriya.realtime.Server()
+    try:
+        boot_options = Options(memory_size=8192 * 32, buffer_count=2048)
+        # Default
+        server.boot(supernova=True)
+        assert isinstance(server.options, type(boot_options))
+        assert server.options.buffer_count == 1024
+        assert server.options.memory_size == 8192
+        server.quit()
+        # With Options
+        server.boot(options=boot_options, supernova=True)
+        assert isinstance(server.options, type(boot_options))
+        assert server.options.buffer_count == 2048
+        assert server.options.memory_size == 8192 * 32
+        server.quit()
+        # With **kwargs
+        server.boot(buffer_count=2048, supernova=True)
+        assert isinstance(server.options, type(boot_options))
+        assert server.options.buffer_count == 2048
+        assert server.options.memory_size == 8192
+        server.quit()
+        # With Options and **kwargs
+        server.boot(buffer_count=4096, options=boot_options, supernova=True)
+        assert isinstance(server.options, type(boot_options))
+        assert server.options.buffer_count == 4096
+        assert server.options.memory_size == 8192 * 32
+        server.quit()
+    finally:
+        if server.is_running:
+            server.quit()
+
+
 @pytest.mark.skip("Reimplementing")
 def test_server_boot_errors(mocker):
     def check_scsynth():
@@ -89,9 +122,32 @@ def test_boot_and_quit():
     assert not server.is_owner
 
 
+def test_boot_and_quit_supernova():
+    server = Server()
+    assert not server.is_running
+    assert not server.is_owner
+    server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+    server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+
+
 def test_boot_and_quit_with_resources():
     server = Server()
     server.boot()
+    server.add_buffer(channel_count=1, frame_count=1024)
+    server.add_bus("audio")
+    server.add_bus("control")
+    server.add_group()
+    server.add_synth()
+    server.quit()
+
+
+def test_boot_and_quit_with_resources_supernova():
+    server = Server()
+    server.boot(supernova=True)
     server.add_buffer(channel_count=1, frame_count=1024)
     server.add_bus("audio")
     server.add_bus("control")
@@ -113,6 +169,19 @@ def test_boot_and_boot():
     assert server.is_owner
 
 
+def test_boot_and_boot_supernova():
+    server = Server()
+    assert not server.is_running
+    assert not server.is_owner
+    server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+    with pytest.raises(exceptions.ServerOnline):
+        server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+
+
 def test_boot_and_quit_and_quit():
     server = Server()
     assert not server.is_running
@@ -128,11 +197,39 @@ def test_boot_and_quit_and_quit():
     assert not server.is_owner
 
 
+def test_boot_and_quit_and_quit_supernova():
+    server = Server()
+    assert not server.is_running
+    assert not server.is_owner
+    server.boot(supernova=True)
+    assert server.is_running
+    assert server.is_owner
+    server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+    server.quit()
+    assert not server.is_running
+    assert not server.is_owner
+
+
 def test_boot_and_connect():
     server = Server()
     assert not server.is_running
     assert not server.is_owner
     server.boot()
+    assert server.is_running
+    assert server.is_owner
+    with pytest.raises(exceptions.ServerOnline):
+        server.connect()
+    assert server.is_running
+    assert server.is_owner
+
+
+def test_boot_and_connect_supernova():
+    server = Server()
+    assert not server.is_running
+    assert not server.is_owner
+    server.boot(supernova=True)
     assert server.is_running
     assert server.is_owner
     with pytest.raises(exceptions.ServerOnline):
@@ -162,6 +259,27 @@ def test_boot_a_and_connect_b():
     assert server_a.query(False) == server_b.query(False)
 
 
+def test_boot_a_and_connect_b_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=4, supernova=True)
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    assert server_a.query(False) == server_b.query(False)
+    assert server_a.client_id == 0 and server_b.client_id == 1
+    assert server_a.default_group.node_id == 1 and server_b.default_group.node_id == 2
+    group = supriya.Group()
+    group.allocate(target_node=server_a)
+    assert server_a.root_node[0][0] is group
+    server_b.sync()
+    assert server_b.root_node[0][0] is not group
+    assert server_a.query(False) == server_b.query(False)
+
+
 def test_boot_a_and_boot_b_cannot_boot():
     server_a, server_b = Server(), Server()
     assert not server_a.is_running and not server_a.is_owner
@@ -171,6 +289,19 @@ def test_boot_a_and_boot_b_cannot_boot():
     assert not server_b.is_running and not server_b.is_owner
     with pytest.raises(exceptions.ServerCannotBoot):
         server_b.boot(maximum_logins=4)
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+
+
+def test_boot_a_and_boot_b_cannot_boot_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=4, supernova=True)
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.ServerCannotBoot):
+        server_b.boot(maximum_logins=4, supernova=True)
     assert server_a.is_running and server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
 
@@ -205,6 +336,23 @@ def test_boot_a_and_connect_b_and_quit_a():
     assert not server_b.is_running and not server_b.is_owner
 
 
+def test_boot_a_and_connect_b_and_quit_a_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=2, supernova=True)
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    server_a.quit()
+    assert not server_a.is_running and not server_a.is_owner
+    for _ in range(45):
+        time.sleep(1)
+        if not server_b.is_running:
+            break
+    assert not server_b.is_running and not server_b.is_owner
+
+
 def test_boot_a_and_connect_b_and_disconnect_b():
     server_a, server_b = Server(), Server()
     assert not server_a.is_running and not server_a.is_owner
@@ -218,11 +366,38 @@ def test_boot_a_and_connect_b_and_disconnect_b():
     assert not server_b.is_running and not server_b.is_owner
 
 
+def test_boot_a_and_connect_b_and_disconnect_b_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=2, supernova=True)
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    server_b.disconnect()
+    assert server_a.is_running and server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+
+
 def test_boot_a_and_connect_b_and_disconnect_a():
     server_a, server_b = Server(), Server()
     assert not server_a.is_running and not server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
     server_a.boot(maximum_logins=2)
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.OwnedServerShutdown):
+        server_a.disconnect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+
+
+def test_boot_a_and_connect_b_and_disconnect_a_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=2, supernova=True)
     server_b.connect()
     assert server_a.is_running and server_a.is_owner
     assert server_b.is_running and not server_b.is_owner
@@ -246,11 +421,42 @@ def test_boot_a_and_connect_b_and_quit_b():
     assert server_b.is_running and not server_b.is_owner
 
 
+def test_boot_a_and_connect_b_and_quit_b_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=2, supernova=True)
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    with pytest.raises(exceptions.UnownedServerShutdown):
+        server_b.quit()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+
+
 def test_boot_a_and_connect_b_and_force_quit_b():
     server_a, server_b = Server(), Server()
     assert not server_a.is_running and not server_a.is_owner
     assert not server_b.is_running and not server_b.is_owner
     server_a.boot(maximum_logins=2)
+    server_b.connect()
+    assert server_a.is_running and server_a.is_owner
+    assert server_b.is_running and not server_b.is_owner
+    server_b.quit(force=True)
+    assert not server_b.is_running and not server_b.is_owner
+    for _ in range(45):
+        time.sleep(1)
+        if not server_a.is_running:
+            break
+    assert not server_a.is_running and not server_a.is_owner
+
+
+def test_boot_a_and_connect_b_and_force_quit_b_supernova():
+    server_a, server_b = Server(), Server()
+    assert not server_a.is_running and not server_a.is_owner
+    assert not server_b.is_running and not server_b.is_owner
+    server_a.boot(maximum_logins=2, supernova=True)
     server_b.connect()
     assert server_a.is_running and server_a.is_owner
     assert server_b.is_running and not server_b.is_owner
@@ -385,6 +591,15 @@ def test_reboot():
     assert server.is_running
 
 
+def test_reboot_supernova():
+    server = Server()
+    server.reboot(supernova=True)
+    assert server.is_running
+    server.reboot(supernova=True)
+    assert server.is_running
+    assert server.is_running
+
+
 def test_reboot_with_resources():
     server = Server()
     server.boot()
@@ -396,11 +611,30 @@ def test_reboot_with_resources():
     server.reboot()
 
 
+def test_reboot_with_resources_supernova():
+    server = Server()
+    server.boot(supernova=True)
+    server.add_buffer(channel_count=1, frame_count=1024)
+    server.add_bus("audio")
+    server.add_bus("control")
+    server.add_group()
+    server.add_synth()
+    server.reboot(supernova=True)
+
+
 def test_reset_and_reboot():
     server = Server()
     server.boot()
     server.reset()
     server.reboot()
+    assert server.is_running
+
+
+def test_reset_and_reboot_supernova():
+    server = Server()
+    server.boot(supernova=True)
+    server.reset()
+    server.reboot(supernova=True)
     assert server.is_running
 
 
@@ -414,4 +648,17 @@ def test_reset_and_reboot_with_resources():
     server.add_synth()
     server.reset()
     server.reboot()
+    assert server.is_running
+
+
+def test_reset_and_reboot_with_resources_supernova():
+    server = Server()
+    server.boot(supernova=True)
+    server.add_buffer(channel_count=1, frame_count=1024)
+    server.add_bus("audio")
+    server.add_bus("control")
+    server.add_group()
+    server.add_synth()
+    server.reset()
+    server.reboot(supernova=True)
     assert server.is_running


### PR DESCRIPTION
Server() doesn't hold any `self._supernova: bool` flag for now.   If the user wants to `.reboot()`, they need to supply the flag again.