### PR TITLE
Watch for NTP timestamp overflow

### DIFF
--- a/supriya/osc/messages.py
+++ b/supriya/osc/messages.py
@@ -362,7 +362,8 @@ class OscBundle(SupriyaValueObject):
             return IMMEDIATELY
         if realtime:
             seconds = seconds + NTP_DELTA
-            return struct.pack(">Q", int(seconds * SECONDS_TO_NTP_TIMESTAMP))
+        if seconds >= 4294967296:  # 2**32
+            seconds = seconds % 4294967296
         return struct.pack(">Q", int(seconds * SECONDS_TO_NTP_TIMESTAMP))
 
     ### PUBLIC METHODS ###

--- a/tests/providers/test_RealtimeProvider.py
+++ b/tests/providers/test_RealtimeProvider.py
@@ -577,8 +577,8 @@ def test_RealtimeProvider_add_group_parallel(server):
     ]
 
 
-@pytest.mark.parametrize("seconds", [100, 2085978495.0, 2085978496.0])
-def test_provider_at_seconds_too_large(server, seconds):
+@pytest.mark.parametrize("seconds", [2085978495.0, 2085978496.0])
+def test_RealtimeProvider_at_new_NTP_era(server, seconds):
     provider = Provider.from_context(server)
     with server.osc_protocol.capture() as transcript:
         with provider.at(seconds):

--- a/tests/providers/test_RealtimeProvider.py
+++ b/tests/providers/test_RealtimeProvider.py
@@ -575,3 +575,15 @@ def test_RealtimeProvider_add_group_parallel(server):
     assert [(_.label, _.message) for _ in transcript] == [
         ("S", OscBundle(contents=(OscMessage("/p_new", 1000, 0, 1),)))
     ]
+
+
+@pytest.mark.parametrize("seconds", [100, 2**31])
+def test_provider_at_seconds_too_large(server, seconds):
+    provider = Provider.from_context(server)
+    with server.osc_protocol.capture() as transcript:
+        with provider.at(seconds):
+            bus_proxy = provider.add_bus()
+            bus_proxy.set_(0)
+    assert [entry.message.to_list() for entry in transcript] == [
+        [seconds + provider.latency, [["/c_set", 0, 0.0]]]
+    ]

--- a/tests/providers/test_RealtimeProvider.py
+++ b/tests/providers/test_RealtimeProvider.py
@@ -577,7 +577,7 @@ def test_RealtimeProvider_add_group_parallel(server):
     ]
 
 
-@pytest.mark.parametrize("seconds", [100, 2**31])
+@pytest.mark.parametrize("seconds", [100, 2085978495.0, 2085978496.0])
 def test_provider_at_seconds_too_large(server, seconds):
     provider = Provider.from_context(server)
     with server.osc_protocol.capture() as transcript:


### PR DESCRIPTION
A new provisional test in `test_RealtimeProvider.py`, `test_provider_seconds_too_large()` fails for `seconds = 2**31 = 2147483648` with the following error message:

```
tests/providers/test_RealtimeProvider.py:584: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
supriya/providers.py:409: in __exit__
    self.provider.server.send(request_bundle.to_osc())
supriya/realtime/servers.py:172: in send
    self._osc_protocol.send(message)
supriya/osc/protocols.py:434: in send
    datagram = self._validate_send(message)
supriya/osc/protocols.py:170: in _validate_send
    datagram = message.to_datagram()
supriya/osc/messages.py:410: in to_datagram
    datagram += self._encode_date(self.timestamp, realtime=realtime)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

seconds = 4356472448.1, realtime = True

    @staticmethod
    def _encode_date(seconds, realtime=True):
        if seconds is None:
            return IMMEDIATELY
        if realtime:
            seconds = seconds + NTP_DELTA
>           return struct.pack(">Q", int(seconds * SECONDS_TO_NTP_TIMESTAMP))
E           struct.error: int too large to convert

supriya/osc/messages.py:365: error
=========================================== short test summary info ===========================================
FAILED tests/providers/test_RealtimeProvider.py::test_provider_at_seconds_too_large[2147483648] - struct.error: int too large to convert
```

Note that in the error report, `seconds = 4356472448.1`

(BTW, this error was discovered by [hypothesis](hypothesis.readthedocs.io/).  Does it alone justify introducing hypothesis framework to Supriya's test suite and using it in the future?)